### PR TITLE
Fixes improper variable reference to SBBackEndAddressPool.

### DIFF
--- a/SACAv2/3NIC_3Tier_HA/azureDeploy.json
+++ b/SACAv2/3NIC_3Tier_HA/azureDeploy.json
@@ -1089,7 +1089,7 @@
                     {
                         "name": "[concat(variables('resourceGroupName'), '-ext-ipconfig3')]",
                         "properties": {
-                            "loadBalancerBackendAddressPools": "variables('SBBackEndAddressPool')",
+                            "loadBalancerBackendAddressPools": "[variables('SBBackEndAddressPool')]",
                             "primary": false,
                             "privateIPAddress": "[concat(variables('ext2SubnetPrivateAddressPrefix'), '.',11)]",
                             "privateIPAllocationMethod": "Static",
@@ -1283,7 +1283,7 @@
                     {
                         "name": "[concat(variables('dnsLabelPrefix'), '-int-ipconfig-secondary')]",
                         "properties": {
-                            "loadBalancerBackendAddressPools": "variables('IPSBackEndAddressPool')",
+                            "loadBalancerBackendAddressPools": "[variables('IPSBackEndAddressPool')]",
                             "privateIPAddress": "[variables('IPSExtSubnetPrivateAddress2')]",
                             "privateIPAllocationMethod": "Static",
                             "subnet": {
@@ -1323,7 +1323,7 @@
                     {
                         "name": "[concat(variables('dnsLabelPrefix'), '-int-ipconfig-secondary')]",
                         "properties": {
-                            "loadBalancerBackendAddressPools": "variables('IPSBackEndAddressPool')",
+                            "loadBalancerBackendAddressPools": "[variables('IPSBackEndAddressPool')]",
                             "privateIPAddress": "[variables('IPSExtSubnetPrivateAddress3')]",
                             "privateIPAllocationMethod": "Static",
                             "subnet": {

--- a/SACAv2/3NIC_3Tier_HA/azureDeploy.json
+++ b/SACAv2/3NIC_3Tier_HA/azureDeploy.json
@@ -1051,7 +1051,7 @@
                     {
                         "name": "[concat(variables('resourceGroupName'), '-ext-ipconfig2')]",
                         "properties": {
-                            "loadBalancerBackendAddressPools": "variables('SBBackEndAddressPool')",
+                            "loadBalancerBackendAddressPools": "[variables('SBBackEndAddressPool')]",
                             "primary": false,
                             "privateIPAddress": "[concat(variables('ext2SubnetPrivateAddressPrefix'), '.',10)]",
                             "privateIPAllocationMethod": "Static",


### PR DESCRIPTION
This PR resolves the following:

* Adds open/close brackets around variable reference to allow ARM to change the value at run-time.

I don't have any F5 licenses to test out deployment, but this was definitely a syntax issue.